### PR TITLE
Switch to class decorator

### DIFF
--- a/simpleformatter/__init__.py
+++ b/simpleformatter/__init__.py
@@ -6,7 +6,7 @@ __author__ = """Ricky L Teachey Jr"""
 __email__ = 'ricky@teachey.org'
 __version__ = '0.1.0'
 
-from .simpleformatter import SimpleFormattable, simpleformatter
+from .simpleformatter import simpleformatter
 
 # Set default logging handler to avoid "No handler found" warnings.
 import logging

--- a/simpleformatter/simpleformatter.py
+++ b/simpleformatter/simpleformatter.py
@@ -1,87 +1,132 @@
 # -*- coding: utf-8 -*-
 
 """Main module."""
+import functools
 from inspect import signature
+from copy import deepcopy
 
 # re-create object.__format__ error message
 default_type_error_msg = "unsupported format string passed to {cls.__qualname__}.__format__"
 
 empty_str = ""  # for readability
+SPECS_HOLDER_ATTR = "_simpleformatter_specs"  # might change this later?
 
 
-def simpleformatter(func=None, *, spec=None):
-    """Decorator for registering formatter specs with formatter functions"""
-    if func is not None and not callable(func):
-        raise TypeError(f"{func.__qualname__!r} func not a callable; spec must be keyword argument")
+class NoArgType:
+    def __repr__(self):
+        return "NO_ARG"
 
-    if spec is None:
-        spec=empty_str
 
-    def mark_simpleformatter_spec(f):
+NO_ARG = NoArgType()
+
+
+def _negotiate_decorator(dec, pos1):
+    """Determine if the decorator was called and act accordingly"""
+
+    if pos1 is NO_ARG:
+        return dec
+    return dec(pos1)
+
+
+def _wrap_cls__format__(cls):
+    """Private function to decorate cls.__format__ function"""
+
+    @functools.wraps(cls.__format__)
+    def _new__format__(self, format_spec=""):
+        """Wrapper for the cls.__format__ method; falls back on default behavior when no formatter found"""
+
         try:
-            specs_set = f._simpleformatter_specs
-        except AttributeError:
-            try:
-                f._simpleformatter_specs = {spec}
-            except TypeError as e:
-                raise SimpleFormatterError("spec must be a valid dict key") from e
-        else:
-            specs_set.add(spec)
-        return f
-
-    if func is None:
-        return mark_simpleformatter_spec
-    else:
-        return mark_simpleformatter_spec(func)
-
-
-class SimpleFormattable:
-    __subclass_dict = dict()
-
-    def __init_subclass__(cls, **kwargs):
-        super().__init_subclass__(**kwargs)
-        cls.__register_marked()
-
-    def __format__(self, format_spec=""):
-        try:
-            # get registered formatter
-            formatter = self.__lookup_formatter(format_spec)
+            formatter = _lookup_formatter(cls, format_spec)
         except SimpleFormatterError as e1:
             try:
-                # format_spec not registered with a formatter; fall back on parent __format__ functionality
-                return super().__format__(format_spec)
+                # formatter not found for format_spec; attempt fall back on default __format__ functionality
+                return cls._default__format__(self, format_spec)
             except Exception as e2:
-                # if parent functionality fails, raise from previous exception for clarity
+                # if default functionality fails, raise from previous exception for clarity
                 raise e2 from e1
         else:
+            # user defined simpleformatter function *may* discard arguments for convenience (staticmethod)
+            if len(signature(formatter).parameters) == 0:
+                return formatter()
             # user defined simpleformatter function *may* discard format_spec argument for convenience (DRY!)
+            # TODO: figure out if want to allow discarding self and keeping format_spec? how to do?
             if len(signature(formatter).parameters) == 1:
                 return formatter(self)
             return formatter(self, format_spec)
 
-    @classmethod
-    def __lookup_formatter(cls, format_spec):
-        """Gets the registered formatting function, raises SimpleFormatterError if one isn't found"""
-        for cls_obj in cls.__mro__:
+    cls.__format__, cls._default__format__ = deepcopy(_new__format__), deepcopy(cls.__format__)
+
+
+def _lookup_formatter(cls, format_spec):
+    """Gets the corresponding formatting function, raises SimpleFormatterError if one isn't found"""
+
+    for cls_obj in cls.__mro__:
+        # traverse in reverse order to get most recently defined formatter for that spec
+        for member in reversed(list(vars(cls_obj).values())):
+            if format_spec in getattr(member, SPECS_HOLDER_ATTR, ()):
+                return member
+    else:
+        raise SimpleFormatterError(f"{format_spec!r} format_spec not registered for {cls.__qualname__} class")
+
+
+def _class_decorator(cls_arg=NO_ARG, *, spec=None, func=None):
+    """Private decorator for adding customized __format__ method to class."""
+
+    def wrap_cls__format__(cls_obj):
+        _wrap_cls__format__(cls_obj)
+        return cls_obj
+
+    return _negotiate_decorator(wrap_cls__format__, cls_arg)
+
+
+def _formatter_func_decorator(func=NO_ARG, *, spec=None):
+    """Private decorator for registering formatter specs with formatter functions"""
+
+    if spec is None:
+        spec = empty_str
+
+    def mark_simpleformatter_spec(f):
+        try:
+            specs_set = getattr(f, SPECS_HOLDER_ATTR)
+        except AttributeError:
             try:
-                return cls.__subclass_dict[cls_obj][format_spec]
-            except KeyError:
-                continue
+                specs_set = {spec}
+            except TypeError as e:
+                raise SimpleFormatterError("spec must be hashable") from e
+            else:
+                setattr(f, SPECS_HOLDER_ATTR, specs_set)
         else:
-            raise SimpleFormatterError(f"{format_spec!r} format_spec not registered for {cls.__qualname__} class")
+            specs_set.add(spec)
+        return f
 
-    @classmethod
-    def __register(cls, spec, func):
-        cls.__subclass_dict[cls][spec] = func
+    return _negotiate_decorator(mark_simpleformatter_spec, func)
 
-    @classmethod
-    def __register_marked(cls):
-        if cls not in cls.__subclass_dict:
-            cls.__subclass_dict[cls]=dict()
-        for member in vars(cls).values():
-            if callable(member) and hasattr(member, "_simpleformatter_specs"):
-                for spec in member._simpleformatter_specs:
-                  cls.__register(spec, member)
+
+def simpleformatter(pos1=NO_ARG, *, spec=None, func=None):
+    """simpleformatter api decorator"""
+
+    # arguments to apply to final returned decorator function
+    dec_kwargs = dict()
+
+    def api_decorator(cls_or_func):
+        """Actual decorator; cls_or_func is either a class or function/method"""
+        if isinstance(cls_or_func, type):
+            # decorator being applied to a class
+            dec_kwargs.update(spec=spec, func=func)
+            return _class_decorator(cls_or_func, **dec_kwargs)
+
+        # assume decorator attempting to be applied to a function/method
+        if not callable(cls_or_func):
+            msg = f"{cls_or_func!r} not a callable" + \
+                  ("; spec must be keyword argument" if isinstance(cls_or_func, str) else "")
+            raise TypeError(msg)
+
+        if func is not None:
+            raise SimpleFormatterError("func argument should only be used when decorating the class")
+        dec_kwargs.update(spec=spec)
+        return _formatter_func_decorator(cls_or_func, **dec_kwargs)
+
+    return _negotiate_decorator(api_decorator, pos1)
 
 
 class SimpleFormatterError(Exception):

--- a/simpleformatter/simpleformatter.py
+++ b/simpleformatter/simpleformatter.py
@@ -149,19 +149,37 @@ def _formatter_func_decorator(pos1, specs):
     return _negotiate_decorator(mark_simpleformatter_spec, pos1)
 
 
-def simpleformatter(pos1=NO_ARG, *specs, formatter_dict=None, **formatter_kwargs):
+def simpleformatter(*specs, formatter_dict=None, **formatter_kwargs):
     """simpleformatter api decorator"""
 
-    if pos1 is not NO_ARG and isinstance(pos1, str):
-        # relocate first argument to specs when it is a spec string
-        # this assumes decorator was applied like:
+    # determine how decorator was applied
+    to_decorate = NO_ARG
+
+    try:
+        # extract first argument to test if it is a spec string
+        pos1, *specs = specs
+    except ValueError:
+        # assume decorator was applied like:
         #
-        #    @simpleformatter.simpleformatter("spec1", "spec2")
-        #    def format_handler(self): ...
-        to_decorate, specs = NO_ARG, (pos1, *specs)
+        #    @simpleformatter.simpleformatter(spec=func)
+        #    class C: ...
+        pass
     else:
-        # first argument is either a class or function/method
-        to_decorate = pos1
+        if isinstance(pos1, str):
+            # assume decorator was applied like:
+            #
+            #    @simpleformatter.simpleformatter("spec1", "spec2")
+            #    def format_handler(self): ...
+            specs = pos1, *specs
+        else:
+            # assume first argument is either a class or function/method:
+            #
+            #    @simpleformatter.simpleformatter
+            #    class C: ...
+            #
+            #    @simpleformatter.simpleformatter
+            #    def f(obj): ...
+            to_decorate = pos1
 
     def api_decorator(cls_or_func):
         """Actual decorator; cls_or_func is either a class or function/method"""

--- a/simpleformatter/simpleformatter.py
+++ b/simpleformatter/simpleformatter.py
@@ -21,7 +21,7 @@ NO_ARG = NoArgType()
 
 
 def _negotiate_decorator(dec, pos1):
-    """Determine if the decorator was called and act accordingly"""
+    """Determine if the decorator was called with or without a first arg when it was invoked and act accordingly"""
 
     if pos1 is NO_ARG:
         return dec
@@ -49,7 +49,7 @@ def _wrap_cls__format__(cls):
             if len(signature(formatter).parameters) == 0:
                 return formatter()
             # user defined simpleformatter function *may* discard format_spec argument for convenience (DRY!)
-            # TODO: figure out if want to allow discarding self and keeping format_spec? how to do?
+            # TODO: figure out if want to allow discarding self and keeping format_spec? how to do? check staticmethod??
             if len(signature(formatter).parameters) == 1:
                 return formatter(self)
             return formatter(self, format_spec)
@@ -66,11 +66,14 @@ def _lookup_formatter(cls, format_spec):
             if format_spec in getattr(member, SPECS_HOLDER_ATTR, ()):
                 return member
     else:
-        raise SimpleFormatterError(f"{format_spec!r} format_spec not registered for {cls.__qualname__} class")
+        raise SimpleFormatterError(f"no {format_spec!r} format_spec found for {cls.__qualname__} class")
 
 
 def _class_decorator(cls_arg=NO_ARG, *, spec=None, func=None):
     """Private decorator for adding customized __format__ method to class."""
+    # TODO: implement spec/formatter handling on the class level:
+    #   @simpleformatter(spec="spec", func=spec_handler)
+    #   class C: ...
 
     def wrap_cls__format__(cls_obj):
         _wrap_cls__format__(cls_obj)
@@ -80,7 +83,7 @@ def _class_decorator(cls_arg=NO_ARG, *, spec=None, func=None):
 
 
 def _formatter_func_decorator(func=NO_ARG, *, spec=None):
-    """Private decorator for registering formatter specs with formatter functions"""
+    """Private decorator for attaching specs to formatter functions"""
 
     if spec is None:
         spec = empty_str
@@ -130,4 +133,5 @@ def simpleformatter(pos1=NO_ARG, *, spec=None, func=None):
 
 
 class SimpleFormatterError(Exception):
+    """I'm an exception. Kneel before me. Lower."""
     pass

--- a/simpleformatter/simpleformatter.py
+++ b/simpleformatter/simpleformatter.py
@@ -10,6 +10,7 @@ default_type_error_msg = "unsupported format string passed to {cls.__qualname__}
 
 empty_str = ""  # for readability
 SPECS_HOLDER_ATTR = "_simpleformatter_specs"  # might change this later?
+SPECS_REG_DICT = "_simpleformatter_registry"
 
 
 class NoArgType:
@@ -26,6 +27,19 @@ def _negotiate_decorator(dec, pos1):
     if pos1 is NO_ARG:
         return dec
     return dec(pos1)
+
+
+def _add_registry(cls, reg):
+    """Attach a formatter registry to the class object"""
+    setattr(cls, SPECS_REG_DICT, reg)
+
+
+def _get_registry(cls):
+    """Retrieve the formatter registry from the class object; raise SimpleFormatterError when not found"""
+    try:
+        return getattr(cls, SPECS_REG_DICT)
+    except AttributeError as e:
+        raise SimpleFormatterError(f"{cls.__qualname__} class has no {SPECS_REG_DICT} registry") from e
 
 
 def _wrap_cls__format__(cls):
@@ -61,62 +75,108 @@ def _lookup_formatter(cls, format_spec):
     """Gets the corresponding formatting function, raises SimpleFormatterError if one isn't found"""
 
     for cls_obj in cls.__mro__:
-        # traverse in reverse order to get most recently defined formatter for that spec
-        for member in reversed(list(vars(cls_obj).values())):
-            if format_spec in getattr(member, SPECS_HOLDER_ATTR, ()):
-                return member
-    else:
-        raise SimpleFormatterError(f"no {format_spec!r} format_spec found for {cls.__qualname__} class")
+        try:
+            return _get_registry(cls_obj)[format_spec]
+        except KeyError:
+            continue
+
+    raise SimpleFormatterError(f"no {format_spec!r} format_spec found for {cls.__qualname__} class")
 
 
-def _class_decorator(cls_arg=NO_ARG, *, spec=None, func=None):
-    """Private decorator for adding customized __format__ method to class."""
+def _register_all_formatters(cls):
+    """Register the formatting functions marked in the class __dict__"""
+
+    formatter_dict = dict()
+
+    # traverse in forward order so most recently defined formatter is registered for each spec
+    for member in vars(cls).values():
+        for format_spec in getattr(member, SPECS_HOLDER_ATTR, ()):
+            formatter_dict.update({format_spec: member})
+
+    try:
+        _register_formatters(cls, formatter_dict)
+    except SimpleFormatterError as e:
+        raise SimpleFormatterError("formatter registration failed due to no formatter registry") from e
+
+
+def _register_formatters(cls, formatter_dict):
+    """Register the spec with its formatting function and place in class registry"""
+    _get_registry(cls).update(formatter_dict)
+
+
+def _class_decorator(pos1, formatter_dict):
+    """Private decorator for adding customized __format__ method and formatter registry to class."""
     # TODO: implement spec/formatter handling on the class level:
     #   @simpleformatter(spec="spec", func=spec_handler)
     #   class C: ...
 
-    def wrap_cls__format__(cls_obj):
-        _wrap_cls__format__(cls_obj)
-        return cls_obj
+    def wrap_cls__format__(cls):
+        _add_registry(cls, formatter_dict)
+        _register_all_formatters(cls)
+        _wrap_cls__format__(cls)
+        return cls
 
-    return _negotiate_decorator(wrap_cls__format__, cls_arg)
+    return _negotiate_decorator(wrap_cls__format__, pos1)
 
 
-def _formatter_func_decorator(func=NO_ARG, *, spec=None):
+def _formatter_func_decorator(pos1, specs):
     """Private decorator for attaching specs to formatter functions"""
 
-    if spec is None:
-        spec = empty_str
+    # spec assumed to be only empty_str when empty
+    if not specs:
+        specs = {empty_str}
 
-    def mark_simpleformatter_spec(f):
+    try:
+        iter_specs = iter(specs)
+    except TypeError as e:
+        raise SimpleFormatterError("specs must be iterable") from e
+
+    try:
+        specs_set = {*iter_specs}
+    except TypeError as e:
+        raise SimpleFormatterError("specs must be hashable") from e
+
+    # internal decorator
+    def mark_simpleformatter_spec(func):
         try:
-            specs_set = getattr(f, SPECS_HOLDER_ATTR)
+            s = getattr(func, SPECS_HOLDER_ATTR)
         except AttributeError:
-            try:
-                specs_set = {spec}
-            except TypeError as e:
-                raise SimpleFormatterError("spec must be hashable") from e
-            else:
-                setattr(f, SPECS_HOLDER_ATTR, specs_set)
+            setattr(func, SPECS_HOLDER_ATTR, specs_set)
         else:
-            specs_set.add(spec)
-        return f
+            s.update(specs_set)
+        return func
 
-    return _negotiate_decorator(mark_simpleformatter_spec, func)
+    return _negotiate_decorator(mark_simpleformatter_spec, pos1)
 
 
-def simpleformatter(pos1=NO_ARG, *, spec=None, func=None):
+def simpleformatter(pos1=NO_ARG, *specs, formatter_dict=None, **formatter_kwargs):
     """simpleformatter api decorator"""
 
-    # arguments to apply to final returned decorator function
-    dec_kwargs = dict()
+    if pos1 is not NO_ARG and isinstance(pos1, str):
+        # relocate first argument to specs when it is a spec string
+        # this assumes decorator was applied like:
+        #
+        #    @simpleformatter.simpleformatter("spec1", "spec2")
+        #    def format_handler(self): ...
+        to_decorate, specs = NO_ARG, (pos1, *specs)
+    else:
+        # first argument is either a class or function/method
+        to_decorate = pos1
 
     def api_decorator(cls_or_func):
         """Actual decorator; cls_or_func is either a class or function/method"""
+
+        nonlocal formatter_dict, specs, formatter_kwargs
+
         if isinstance(cls_or_func, type):
             # decorator being applied to a class
-            dec_kwargs.update(spec=spec, func=func)
-            return _class_decorator(cls_or_func, **dec_kwargs)
+            if specs:
+                raise SimpleFormatterError("specs arguments should only be used when decorating a function")
+            if formatter_dict is None:
+                formatter_dict = dict(**formatter_kwargs)
+            else:
+                formatter_dict.update(**formatter_kwargs)
+            return _class_decorator(cls_or_func, formatter_dict)
 
         # assume decorator attempting to be applied to a function/method
         if not callable(cls_or_func):
@@ -124,12 +184,13 @@ def simpleformatter(pos1=NO_ARG, *, spec=None, func=None):
                   ("; spec must be keyword argument" if isinstance(cls_or_func, str) else "")
             raise TypeError(msg)
 
-        if func is not None:
-            raise SimpleFormatterError("func argument should only be used when decorating the class")
-        dec_kwargs.update(spec=spec)
-        return _formatter_func_decorator(cls_or_func, **dec_kwargs)
+        if formatter_kwargs:
+            raise SimpleFormatterError("formatter_kwargs arguments should only be used when decorating the class")
+        if formatter_dict is not None:
+            raise SimpleFormatterError("formatter_dict argument should only be used when decorating the class")
+        return _formatter_func_decorator(cls_or_func, specs)
 
-    return _negotiate_decorator(api_decorator, pos1)
+    return _negotiate_decorator(api_decorator, to_decorate)
 
 
 class SimpleFormatterError(Exception):

--- a/tests/test_simpleformatter.py
+++ b/tests/test_simpleformatter.py
@@ -39,7 +39,8 @@ def SimpleFormatterError(simpleformatter):
 
 @pytest.fixture
 def A(simpleformatter):
-    class A(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class A:
         """A class that has a custom formatting function decorated by simpleformatter
 
         the function accepts no arguments so no spec is allowed other than the default, empty_str"""
@@ -65,7 +66,8 @@ def example_a(A):
 
 @pytest.fixture
 def B(simpleformatter):
-    class B(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class B:
         """A class that has a custom formatting function decorated by simpleformatter, with spec = 'special_'"""
         test_results = defaultdict(lambda: None)
 
@@ -100,7 +102,8 @@ def example_b(B):
 
 @pytest.fixture
 def C(simpleformatter):
-    class C(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class C:
         """A class that has a custom formatting function decorated by simpleformatter, with spec = 'special_'"""
         test_results = defaultdict(lambda: None)
 
@@ -131,7 +134,8 @@ def example_c(C):
 
 @pytest.fixture
 def D(simpleformatter):
-    class D(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class D:
         """A class that assigns a custom external Formatter api object"""
         # TODO: figure out if this makes sense
         pass
@@ -144,7 +148,7 @@ def example_d(D):
     return D()
 
 
-### example fixture tests (does NOT test the api!!) ####################################################################
+# example fixture tests (does NOT test the api!!) ######################################################################
 
 @pytest.mark.parametrize("cls_name, formatter_name, spec", [
     ("A", "A.my_formatter", empty_str),
@@ -181,7 +185,7 @@ def test_formatter_function(cls_name, formatter_name, spec, A, example_a, B, exa
             assert formatter(obj) == result
 
 
-### api tests ##########################################################################################################
+# api tests ############################################################################################################
 
 @pytest.mark.parametrize("cls_name, spec", [
     ("A", empty_str),
@@ -220,7 +224,8 @@ def test_simpleformatter_api(cls_name, spec, A, example_a, B, example_b, C, exam
 def test_ambiguous_no_spec_inheritance(simpleformatter):
     """last defined spec wins with competing functions"""
 
-    class X(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class X:
 
         @simpleformatter.simpleformatter
         def a(self):
@@ -230,16 +235,18 @@ def test_ambiguous_no_spec_inheritance(simpleformatter):
         def b(self):
             return "b"
 
-    assert f"{X()}"==X().b()
+    assert f"{X()}" == X().b()
 
+    @simpleformatter.simpleformatter
     class Y(X):
 
         @simpleformatter.simpleformatter
         def c(self):
             return "c"
 
-    assert f"{Y()}"==Y().c()
+    assert f"{Y()}" == Y().c()
 
+    @simpleformatter.simpleformatter
     class Z(Y):
 
         @simpleformatter.simpleformatter
@@ -250,13 +257,14 @@ def test_ambiguous_no_spec_inheritance(simpleformatter):
         def c(self):
             return "e"
 
-    assert f"{Z()}"=="e"
+    assert f"{Z()}" == "e"
 
 
 def test_ambiguous_competing(simpleformatter):
     """last defined spec wins with two competing functions for SAME format spec"""
 
-    class X(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class X:
 
         @simpleformatter.simpleformatter(spec="spec")
         def a(self):
@@ -266,13 +274,14 @@ def test_ambiguous_competing(simpleformatter):
         def b(self):
             return "b"
 
-    assert f"{X():spec}"==X().b()
+    assert f"{X():spec}" == X().b()
 
 
 def test_ambiguous_special(simpleformatter):
     """last defined spec wins with two competing functions, one with no spec and one with empty_str spec"""
 
-    class X(simpleformatter.SimpleFormattable):
+    @simpleformatter.simpleformatter
+    class X:
 
         @simpleformatter.simpleformatter
         def a(self):
@@ -282,4 +291,4 @@ def test_ambiguous_special(simpleformatter):
         def b(self):
             return "b"
 
-    assert f"{X()}"==X().b()
+    assert f"{X()}" == X().b()

--- a/tests/test_simpleformatter.py
+++ b/tests/test_simpleformatter.py
@@ -82,12 +82,12 @@ def B(simpleformatter):
         test_results["specialz"] = "class B object spec = 'specialyz'"
 
         @simpleformatter.simpleformatter
-        @simpleformatter.simpleformatter(spec="specialx")
+        @simpleformatter.simpleformatter("specialx")
         def specialx_formatter(self, spec):
             return f"class B object spec = {spec!r}"
 
-        @simpleformatter.simpleformatter(spec="specialy")
-        @simpleformatter.simpleformatter(spec="specialz")
+        @simpleformatter.simpleformatter("specialy")
+        @simpleformatter.simpleformatter("specialz")
         def specialyz_formatter(self):
             return str(self) + " spec = 'specialyz'"
 
@@ -119,9 +119,9 @@ def C(simpleformatter):
         test_results["specialy"] = "class C object spec = 'specialy'"
         test_results["specialz"] = "class C object spec = 'specialz'"
 
-        @simpleformatter.simpleformatter(spec="specialx")
-        @simpleformatter.simpleformatter(spec="specialy")
-        @simpleformatter.simpleformatter(spec="specialz")
+        @simpleformatter.simpleformatter("specialx")
+        @simpleformatter.simpleformatter("specialy")
+        @simpleformatter.simpleformatter("specialz")
         def special_formatter(self, spec):
             return f"class C object spec = {spec!r}"
 
@@ -141,7 +141,7 @@ def ex_c(C):
 @pytest.fixture
 def D(simpleformatter, my_formatter):
 
-    @simpleformatter.simpleformatter(spec="spec", func=my_formatter)
+    @simpleformatter.simpleformatter(spec=my_formatter)
     class D:
         """api decorated class, with externally defined formatting"""
         test_results = defaultdict(lambda: None)
@@ -219,11 +219,13 @@ def test_formatter_function(cls_name, formatter_name, spec, A, ex_a, B, ex_b, C,
         try:
             formatter(obj, spec)
         except TypeError:
+            # single argument
             formatter(obj)
     else:
         try:
             assert formatter(obj, spec) == result
         except TypeError:
+            # single argument
             assert formatter(obj) == result
 
 
@@ -255,15 +257,9 @@ def test_simpleformatter_api(cls_name, spec, A, ex_a, B, ex_b, C, ex_c, D, ex_d,
     result = cls.test_results[spec]
     if result is None:
         with pytest.raises(TypeError):
-            if spec is None:
-                f"{obj}"
-            else:
-                f"{obj:{spec!s}}"
+            f"{obj:{spec!s}}"
     else:
-        if spec is None:
-            assert f"{obj}" == result
-        else:
-            assert f"{obj:{spec!s}}" == result
+        assert f"{obj:{spec!s}}" == result
 
 
 def test_ambiguous_no_spec_and_inheritance(simpleformatter):
@@ -311,11 +307,11 @@ def test_ambiguous_competing(simpleformatter):
     @simpleformatter.simpleformatter
     class X:
 
-        @simpleformatter.simpleformatter(spec="spec")
+        @simpleformatter.simpleformatter("spec")
         def a(self):
             return "a"
 
-        @simpleformatter.simpleformatter(spec="spec")
+        @simpleformatter.simpleformatter("spec")
         def b(self):
             return "b"
 
@@ -332,7 +328,7 @@ def test_ambiguous_special(simpleformatter):
         def a(self):
             return "a"
 
-        @simpleformatter.simpleformatter(spec=empty_str)
+        @simpleformatter.simpleformatter(empty_str)
         def b(self):
             return "b"
 


### PR DESCRIPTION
Leaving behind the idea of using inheritance to change the __format__ method behavior of classes and using a class decorator instead.

Chose to use the *same* decorator for both classes and functions/methods. this seems convenient.